### PR TITLE
lib65816 patches

### DIFF
--- a/lib65816/cpu.h
+++ b/lib65816/cpu.h
@@ -142,11 +142,15 @@ extern word32   cpu_cycle_count;
  *
  * The SYNC pin is useful to trap OS calls, whereas the VP pin is
  * needed to emulate hardware which modifies the vector addresses.
+ *
+ * The M_PEEK is for reading memory without side effects, esp.
+ * for the debugger.
  */
 
 #define EMUL_PIN_SYNC 1 // much more work to provide VPD and VPA
 #define EMUL_PIN_VP   2
 #define M_READ(a)         MEM_readMem(a, cpu_cycle_count, 0)
+#define M_PEEK(a)         MEM_peekMem(a, cpu_cycle_count, 0)
 #define M_READ_OPCODE(a)  MEM_readMem(a, cpu_cycle_count, EMUL_PIN_SYNC)
 #define M_READ_VECTOR(a)  MEM_readMem(a, cpu_cycle_count, EMUL_PIN_VP)
 #define M_WRITE(a,v)      MEM_writeMem((a),(v), cpu_cycle_count)
@@ -239,6 +243,7 @@ void CPU_setDbgOutfile(FILE *f);
 void EMUL_handleWDM(byte opcode, word32 timestamp);
 void EMUL_hardwareUpdate(word32 timestamp);
 byte MEM_readMem(word32 address, word32 timestamp, word32 emulFlags);
+byte MEM_peekMem(word32 address, word32 timestamp, word32 emulFlags);
 void MEM_writeMem(word32 address, byte b, word32 timestamp);
 
 #endif /* _CPU_H */

--- a/lib65816/cpu.h
+++ b/lib65816/cpu.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #endif
 
+#include <stdio.h>
+
 /*
  * lib65816/cpu.h Release 1p1
  * See LICENSE for more details.
@@ -221,6 +223,10 @@ void CPU_modeSwitch(void);
 
 void CPU_debug(void);
 
+/* Set the output file of the debugger trace output. */
+/* Default is stdout */
+
+void CPU_setDbgOutfile(FILE *f);
 
 /* These are used by the various macros above, so make sure that we
  * declare them for type safety purposes!  Thanks to fabys for these on

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -140,7 +140,7 @@ void CPU_debug(void) {
 		out = stdout;
 	}
 
-	opcode = M_READ(PC.A);
+	opcode = M_PEEK(PC.A);
 	mode = addrmodes[opcode];
 	fprintf(out, "A=%04X X=%04X Y=%04X S=%04X D=%04X B=%02X P=%02X (%c%c%c%c%c%c%c%c) E=%1d  ",
 			(int) A.W, (int) X.W, (int) Y.W, (int) S.W, (int) D.W, (int) DB,
@@ -151,17 +151,17 @@ void CPU_debug(void) {
 	fprintf(out, "%02X/%04X  %s ",(int) PC.B.PB,(int) PC.W.PC,mnemonics[opcode]);
 	switch (mode) {
         case IMM8:
-            sprintf( operands, "#$%02X", M_READ(PC.A+1) );
+            sprintf( operands, "#$%02X", M_PEEK(PC.A+1) );
             break;
 
         case IMM:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
             if( F_getM ) sprintf( operands, "#$%02X", (operand & 0xFF));
             else         sprintf( operands, "#$%04X", operand );
             break;
 
         case IMMX:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
             if( F_getX ) sprintf( operands, "#$%02X", (operand & 0xFF));
             else         sprintf( operands, "#$%04X", operand );
             break;
@@ -171,12 +171,12 @@ void CPU_debug(void) {
             break;
 
         case PCR:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             sprintf( operands, "$%02X ($%02X%04X)", operand, PC.B.PB, PC.W.PC + operand + 2);
             break;
 
         case PCRL:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
             sprintf( operands, "$%02X ($%02X%04X)", operand, PC.B.PB, PC.W.PC + operand + 3);
             break;
 
@@ -185,143 +185,143 @@ void CPU_debug(void) {
             break;
 
         case DP:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             ea = D.W + operand;
             sprintf( operands, "$%02X (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case DPX:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             if( F_getX ) ea = D.W + operand + X.B.L;
             else         ea = D.W + operand + X.W;
             sprintf( operands, "$%02X,X (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case DPY:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             if( F_getX ) ea = D.W + operand + Y.B.L;
             else         ea = D.W + operand + Y.W;
             sprintf( operands, "$%02X,Y (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case DPI:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             ea = D.W + operand;
-            ea = M_READ(ea) | (M_READ(ea+1)<<8) | (DB<<16);
+            ea = M_PEEK(ea) | (M_PEEK(ea+1)<<8) | (DB<<16);
             sprintf( operands, "($%02X) (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case DPIX:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             if( F_getX ) ea = D.W + operand + X.B.L;
             else         ea = D.W + operand + X.W;
-            ea = M_READ(ea) | (M_READ(ea+1)<<8) | (DB<<16);
+            ea = M_PEEK(ea) | (M_PEEK(ea+1)<<8) | (DB<<16);
             sprintf( operands, "($%02X,X) (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case DPIY:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             ea = D.W + operand;
-            if( F_getX ) ea = M_READ(ea) | (M_READ(ea+1)<<8) | (DB<<16) + Y.B.L;
-            else         ea = M_READ(ea) | (M_READ(ea+1)<<8) | (DB<<16) + Y.W;
+            if( F_getX ) ea = M_PEEK(ea) | (M_PEEK(ea+1)<<8) | (DB<<16) + Y.B.L;
+            else         ea = M_PEEK(ea) | (M_PEEK(ea+1)<<8) | (DB<<16) + Y.W;
             sprintf( operands, "($%02X),Y (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case DPIL:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             ea = D.W + operand;
-            ea = M_READ(ea) | (M_READ(ea+1)<<8) | (M_READ(ea+2)<<16);
+            ea = M_PEEK(ea) | (M_PEEK(ea+1)<<8) | (M_PEEK(ea+2)<<16);
             sprintf( operands, "[$%02X] (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case DPILY:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             ea = D.W + operand;
-            if( F_getX ) ea = M_READ(ea) | (M_READ(ea+1)<<8) | (M_READ(ea+2)<<16) + Y.B.L;
-            else         ea = M_READ(ea) | (M_READ(ea+1)<<8) | (M_READ(ea+2)<<16) + Y.W;
+            if( F_getX ) ea = M_PEEK(ea) | (M_PEEK(ea+1)<<8) | (M_PEEK(ea+2)<<16) + Y.B.L;
+            else         ea = M_PEEK(ea) | (M_PEEK(ea+1)<<8) | (M_PEEK(ea+2)<<16) + Y.W;
             sprintf( operands, "[$%02X],Y (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case ABS:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
             ea = operand + (DB<<16);
             sprintf( operands, "$%04X (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case ABSX:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
             if( F_getX ) ea = operand + (DB<<16) + X.B.L;
             else         ea = operand + (DB<<16) + X.W;
             sprintf( operands, "$%04X,X (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case ABSY:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
             if( F_getX ) ea = operand + (DB<<16) + Y.B.L;
             else         ea = operand + (DB<<16) + Y.W;
             sprintf( operands, "$%04X,Y (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case ABSL:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8) | (M_READ(PC.A+3)<<16);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8) | (M_PEEK(PC.A+3)<<16);
             ea = operand;
             sprintf( operands, "$%06X (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case ABSLX:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8) | (M_READ(PC.A+3)<<16);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8) | (M_PEEK(PC.A+3)<<16);
             if( F_getX ) ea = operand + X.B.L;
             else         ea = operand + X.W;
             sprintf( operands, "$%06X (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case ABSI:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
-            ea = M_READ(operand) + (M_READ(operand+1)<<8) + (DB<<16);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
+            ea = M_PEEK(operand) + (M_PEEK(operand+1)<<8) + (DB<<16);
             sprintf( operands, "$%04X (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case ABSIX:
-            operand = M_READ(PC.A+1) | (M_READ(PC.A+2)<<8);
+            operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
             ea = operand | (PC.B.PB << 16);
-            ea = M_READ(ea) + (M_READ(ea+1)<<8) + (PC.B.PB<<16);
+            ea = M_PEEK(ea) + (M_PEEK(ea+1)<<8) + (PC.B.PB<<16);
             sprintf( operands, "($%04X,X) (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case STK:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             ea = operand + S.W;
             sprintf( operands, "$%02X,S (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case STKIY:
-            operand = M_READ(PC.A+1);
+            operand = M_PEEK(PC.A+1);
             ea = operand + S.W;
-            if( F_getX ) ea = M_READ(ea) + (M_READ(ea+1)<<8) + (DB<<16) + Y.B.L;
-            else         ea = M_READ(ea) + (M_READ(ea+1)<<8) + (DB<<16) + Y.W;
+            if( F_getX ) ea = M_PEEK(ea) + (M_PEEK(ea+1)<<8) + (DB<<16) + Y.B.L;
+            else         ea = M_PEEK(ea) + (M_PEEK(ea+1)<<8) + (DB<<16) + Y.W;
 
             sprintf( operands, "$%02X,S (@%06X %02X %02X %02X ...)",
-                operand, ea, M_READ(ea), M_READ(ea+1), M_READ(ea+2) );
+                operand, ea, M_PEEK(ea), M_PEEK(ea+1), M_PEEK(ea+2) );
             break;
 
         case BLK:
-            sprintf( operands, "$%02X, $%02X", M_READ(PC.A+2), M_READ(PC.A+1) );
+            sprintf( operands, "$%02X, $%02X", M_PEEK(PC.A+2), M_PEEK(PC.A+1) );
             break;
 	}
         fprintf( out, "%s\n", operands );

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -17,6 +17,8 @@
 
 #include "cpumicro.h"
 
+FILE *out = NULL;
+
 /* 65816 debugger module */
 
 char *mnemonics[256] = {
@@ -123,6 +125,10 @@ int addrmodes[256] = {
 
 extern int cpu_irq;
 
+void CPU_setDbgOutfile(FILE *f) {
+	out = f;
+}
+
 void CPU_debug(void) {
 	int	opcode;
 	int	mode;
@@ -130,15 +136,19 @@ void CPU_debug(void) {
     int ea;
     char operands[40];
 
+	if (out == NULL) {
+		out = stdout;
+	}
+
 	opcode = M_READ(PC.A);
 	mode = addrmodes[opcode];
-	printf("A=%04X X=%04X Y=%04X S=%04X D=%04X B=%02X P=%02X (%c%c%c%c%c%c%c%c) E=%1d  ",
+	fprintf(out, "A=%04X X=%04X Y=%04X S=%04X D=%04X B=%02X P=%02X (%c%c%c%c%c%c%c%c) E=%1d  ",
 			(int) A.W, (int) X.W, (int) Y.W, (int) S.W, (int) D.W, (int) DB,
 			(int) P,
 			(F_getN?'N':'n'), (F_getV?'V':'v'), (F_getM?'M':'m'), (F_getX?'X':'x'),
 			(F_getD?'D':'d'), (F_getI?'I':'i'), (F_getZ?'Z':'z'), (F_getC?'C':'c'),
 			(int) E);
-	printf("%02X/%04X  %s ",(int) PC.B.PB,(int) PC.W.PC,mnemonics[opcode]);
+	fprintf(out, "%02X/%04X  %s ",(int) PC.B.PB,(int) PC.W.PC,mnemonics[opcode]);
 	switch (mode) {
         case IMM8:
             sprintf( operands, "#$%02X", M_READ(PC.A+1) );
@@ -314,8 +324,8 @@ void CPU_debug(void) {
             sprintf( operands, "$%02X, $%02X", M_READ(PC.A+2), M_READ(PC.A+1) );
             break;
 	}
-    printf( "%s\n", operands );
-	fflush(stdout);
+        fprintf( out, "%s\n", operands );
+	fflush(out);
 }
 
 #endif

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -149,6 +149,10 @@ void CPU_debug(void) {
 			(F_getD?'D':'d'), (F_getI?'I':'i'), (F_getZ?'Z':'z'), (F_getC?'C':'c'),
 			(int) E);
 	fprintf(out, "%02X/%04X  %s ",(int) PC.B.PB,(int) PC.W.PC,mnemonics[opcode]);
+
+	/* prevent error printing implied */
+	operands[0] = 0;
+
 	switch (mode) {
         case IMM8:
             sprintf( operands, "#$%02X", M_PEEK(PC.A+1) );
@@ -172,12 +176,12 @@ void CPU_debug(void) {
 
         case PCR:
             operand = M_PEEK(PC.A+1);
-            sprintf( operands, "$%02X ($%02X%04X)", operand, PC.B.PB, PC.W.PC + operand + 2);
+            sprintf( operands, "$%02X ($%02X%04X)", operand, PC.B.PB, PC.W.PC + operand + 2 - ((operand > 127) ? 256 : 0));
             break;
 
         case PCRL:
             operand = M_PEEK(PC.A+1) | (M_PEEK(PC.A+2)<<8);
-            sprintf( operands, "$%02X ($%02X%04X)", operand, PC.B.PB, PC.W.PC + operand + 3);
+            sprintf( operands, "$%02X ($%02X%04X)", operand, PC.B.PB, PC.W.PC + operand + 3 - ((operand > 32767) ? 65536 : 0));
             break;
 
         case IMPL:


### PR DESCRIPTION
See the included patches:
- allow re-directing debugger output to a file
- add MEM_peek() / M_PEEK() so that the debugger runs without side effects in environments that have those (register that changes / trigger actions on read). This is not a recommended behaviour, but happens, and can be mitigated in the 65816 with VDA/VPA, so should finally be ok in the 65xx world
- small display fixes in the debugger